### PR TITLE
Fixes for typo

### DIFF
--- a/01-resources.sh
+++ b/01-resources.sh
@@ -2,7 +2,7 @@
 
 # Set resources path
 RESOURCES_PATH=/home/user/resources
-mkdir -p $ RESOURCES_PATH
+mkdir -p $RESOURCES_PATH
 CWD=`pwd`
 
 # Download reference genome

--- a/02-software.sh
+++ b/02-software.sh
@@ -146,7 +146,7 @@ ARCHIVE=`basename $LINK`
 tar -xvf $ARCHIVE
 rm $ARCHIVE
 export BEDTOOLS_PATH=$INSTALL_PATH/bedtools2/bin
-cd BEDTOOLS_PATH/..
+cd $BEDTOOLS_PATH/..
 make
 cd $CWD
 

--- a/03-data.sh
+++ b/03-data.sh
@@ -3,7 +3,7 @@
 # Setup paths
 HOME_PATH=/home/user/analysis
 FASTQ_PATH=$HOME_PATH/fastq
-mkdir -p $ FASTQ_PATH
+mkdir -p $FASTQ_PATH
 cd $CWD
 
 # Download raw data from 1000 genomes project

--- a/05-trimgalore.sh
+++ b/05-trimgalore.sh
@@ -22,7 +22,7 @@ do
     $TRIMGALORE_COMMAND \
         --quality 30 \
         --length 50 \
-        --output_dir $TRIMGALORE_OUTPUT/$BASE \
+        --output_dir $TRIMGALORE_OUTPUT/ \
         --path_to_cutadapt $CUTADAPT_COMMAND \
         --cores 4 \
         --paired \

--- a/08-preparebam.sh
+++ b/08-preparebam.sh
@@ -11,7 +11,7 @@ do
     echo "Processing $SAMPLE"
     $SAMTOOLS_PATH/samtools sort -n -@ $CORES -m 4G \
         $BAM_PATH/$SAMPLE".uns" | \
-    $SAMTOOLS_PATH/samtools fixmate -m - 
+    $SAMTOOLS_PATH/samtools fixmate -m - \
     $BAM_PATH/$SAMPLE"_fixmate.bam"
 done
 rm $BAM_PATH/*.uns

--- a/09-bamstats.sh
+++ b/09-bamstats.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CAPTURE_KIT=$HOME_PATH/resources/panel/Agilent_SureSelect_All_Exon_V2.bed
+CAPTURE_KIT=$RESOURCES_PATH/panel/Agilent_SureSelect_All_Exon_V2.bed
 BAM_PATH=$HOME_PATH/bam
 REPORT=$HOME_PATH/reports/finalbamstats.txt
 mkdir $HOME_PATH/reports

--- a/11-bqsr.sh
+++ b/11-bqsr.sh
@@ -4,8 +4,8 @@ BAM_PATH=$HOME_PATH/bam
 CAPTURE_KIT=$RESOURCES_PATH/panel/Agilent_SureSelect_All_Exon_V2.bed
 INTERVAL_LIST_PATH=$HOME_PATH/resources/interval_scatter
 BWA_INDEX=$RESOURCES_PATH/hs37d5/hs37d5.fa
-DBSNP=$RESOURCES_PATH/dbSNP151.vcf
-GNOMAD=$RESOURCES_PATH/gnomad.exomes.r2.1.1.sites.vcf.bgz
+DBSNP=$RESOURCES_PATH/dbSNP/dbSNP151.vcf
+GNOMAD=$RESOURCES_PATH/gnomAD/gnomad.exomes.r2.1.1.sites.vcf.bgz
 CORES=16
 PADDING=50
 

--- a/13-freebayes.sh
+++ b/13-freebayes.sh
@@ -82,7 +82,7 @@ cat $VCF_PATH/*.vcf | \
     $VCFLIB_PATH/scripts/vcffirstheader | \
     $VCFLIB_PATH/bin/vcfstreamsort -w 1000 | \
     $VCFLIB_PATH/bin/vcfuniq > \
-    $VCF_PATH/all_samples_freebayes.vcf
+    $VCF_PATH/freebayes_full.vcf
 
 echo "=== Compressing and indexing final VCF" >> $META_REPORT
 $HTSLIB_PATH/bgzip $VCF_PATH/freebayes_full.vcf


### PR DESCRIPTION
This extra space will result in script downloads into wrong directory (current active directory).